### PR TITLE
Fix.#011 member count dev

### DIFF
--- a/src/main/java/me/golf/blog/domain/auth/application/AuthService.java
+++ b/src/main/java/me/golf/blog/domain/auth/application/AuthService.java
@@ -16,16 +16,17 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class AuthService {
     private final MemberRepository memberRepository;
     private final AuthenticationManagerBuilder managerBuilder;
     private final TokenProvider tokenProvider;
 
     public TokenDTO login(final Email email, final Password password) {
-        final String userEmail = email.email();
         final String userPw = password.password();
 
         CustomUserDetails userDetails = memberRepository.findByEmail(email)
@@ -38,7 +39,7 @@ public class AuthService {
         Authentication authenticate = managerBuilder.getObject().authenticate(token);
         SecurityContextHolder.getContext().setAuthentication(authenticate);
 
-        return tokenProvider.createToken(userEmail, authenticate);
+        return tokenProvider.createToken(userDetails.getId(), authenticate);
     }
 
     public AccessToken reissue(final String refreshToken) {
@@ -49,6 +50,6 @@ public class AuthService {
         Authentication authentication = tokenProvider.getAuthentication(refreshToken);
         CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        return tokenProvider.createToken(principal.getUsername(), authentication).getAccessToken();
+        return tokenProvider.createToken(principal.getId(), authentication).getAccessToken();
     }
 }

--- a/src/main/java/me/golf/blog/domain/auth/application/AuthService.java
+++ b/src/main/java/me/golf/blog/domain/auth/application/AuthService.java
@@ -1,10 +1,10 @@
 package me.golf.blog.domain.auth.application;
 
 import lombok.RequiredArgsConstructor;
+import me.golf.blog.domain.member.domain.persist.MemberQueryRepository;
 import me.golf.blog.global.jwt.error.TokenNotFoundException;
 import me.golf.blog.global.jwt.vo.AccessToken;
 import me.golf.blog.global.security.principal.CustomUserDetails;
-import me.golf.blog.domain.member.domain.persist.MemberRepository;
 import me.golf.blog.domain.member.domain.vo.Email;
 import me.golf.blog.domain.member.domain.vo.Password;
 import me.golf.blog.domain.member.error.MemberNotFoundException;
@@ -22,15 +22,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class AuthService {
-    private final MemberRepository memberRepository;
+    private final MemberQueryRepository memberQueryRepository;
     private final AuthenticationManagerBuilder managerBuilder;
     private final TokenProvider tokenProvider;
 
     public TokenDTO login(final Email email, final Password password) {
         final String userPw = password.password();
 
-        CustomUserDetails userDetails = memberRepository.findByEmail(email)
-                .map(CustomUserDetails::of)
+        CustomUserDetails userDetails = memberQueryRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         UsernamePasswordAuthenticationToken token

--- a/src/main/java/me/golf/blog/domain/auth/dto/AccessTokenResponse.java
+++ b/src/main/java/me/golf/blog/domain/auth/dto/AccessTokenResponse.java
@@ -12,7 +12,6 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AccessTokenResponse {
-    @NotBlank(message = "")
     private AccessToken accessToken;
 
     public static AccessTokenResponse from(final AccessToken accessToken) {

--- a/src/main/java/me/golf/blog/domain/board/api/BoardController.java
+++ b/src/main/java/me/golf/blog/domain/board/api/BoardController.java
@@ -32,7 +32,7 @@ public class BoardController {
         return ResponseEntity.status(HttpStatus.CREATED).body(boardService.create(request.toEntity(), getPrincipal().getId()));
     }
 
-    @GetMapping("/boards/{boardId}")
+    @GetMapping("/public/boards/{boardId}")
     public ResponseEntity<BoardResponse> findById(@PathVariable Long boardId) {
         return ResponseEntity.ok(boardReadService.findById(boardId));
     }

--- a/src/main/java/me/golf/blog/domain/board/application/BoardService.java
+++ b/src/main/java/me/golf/blog/domain/board/application/BoardService.java
@@ -8,11 +8,14 @@ import me.golf.blog.domain.board.dto.BoardDTO;
 import me.golf.blog.domain.board.dto.BoardResponse;
 import me.golf.blog.domain.board.error.BoardMissMatchException;
 import me.golf.blog.domain.board.error.BoardNotFoundException;
+import me.golf.blog.domain.boardCount.application.BoardCountService;
 import me.golf.blog.domain.boardCount.domain.persist.BoardCount;
 import me.golf.blog.domain.boardCount.domain.persist.BoardCountRepository;
 import me.golf.blog.domain.member.domain.persist.Member;
 import me.golf.blog.domain.member.domain.persist.MemberRepository;
 import me.golf.blog.domain.member.error.MemberNotFoundException;
+import me.golf.blog.domain.memberCount.application.MemberCountService;
+import me.golf.blog.domain.memberCount.domain.persist.MemberCount;
 import me.golf.blog.global.error.exception.ErrorCode;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
@@ -29,14 +32,14 @@ import java.util.stream.Collectors;
 public class BoardService {
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
-    private final BoardCountRepository boardCountRepository;
+    private final BoardCountService boardCountService;
+    private final MemberCountService memberCountService;
 
     public Long create(final Board board, final Long memberId) {
         Member member = getMember(memberId);
-        board.addMember(member);
-        Board savedBoard = boardRepository.save(board);
-        BoardCount boardCount = BoardCount.createBoardCount(savedBoard);
-        boardCountRepository.save(boardCount);
+        Board savedBoard = boardRepository.save(board.addMember(member));
+        boardCountService.saveBoardCount(board);
+        memberCountService.increaseBoardCount(member);
         return savedBoard.getId();
     }
 

--- a/src/main/java/me/golf/blog/domain/board/domain/persist/BoardQueryRepository.java
+++ b/src/main/java/me/golf/blog/domain/board/domain/persist/BoardQueryRepository.java
@@ -21,9 +21,9 @@ public class BoardQueryRepository {
     public List<BoardAllResponse> findAll(final SearchKeywordRequest searchKeyword, final Pageable pageable) {
         return query.selectFrom(board)
                 .where(
-                        eqByTitle(searchKeyword.getByTitle()),
-                        eqByContent(searchKeyword.getByContent()),
-                        eqByNickname(searchKeyword.getByEmail())
+                        eqTitle(searchKeyword.getTitle()),
+                        eqContent(searchKeyword.getContent()),
+                        eqNickname(searchKeyword.getEmail())
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -33,21 +33,21 @@ public class BoardQueryRepository {
                 .collect(Collectors.toList());
     }
 
-    private BooleanExpression eqByTitle(final String byTitle) {
+    private BooleanExpression eqTitle(final String byTitle) {
         if (!StringUtils.hasText(byTitle)) {
             return null;
         }
         return board.title.title.contains(byTitle);
     }
 
-    private BooleanExpression eqByContent(final String byContent) {
+    private BooleanExpression eqContent(final String byContent) {
         if (!StringUtils.hasText(byContent)) {
             return null;
         }
         return board.content.content.contains(byContent);
     }
 
-    private BooleanExpression eqByNickname(final String byNickname) {
+    private BooleanExpression eqNickname(final String byNickname) {
         if (!StringUtils.hasText(byNickname)) {
             return null;
         }

--- a/src/main/java/me/golf/blog/domain/board/domain/persist/SearchKeywordRequest.java
+++ b/src/main/java/me/golf/blog/domain/board/domain/persist/SearchKeywordRequest.java
@@ -1,17 +1,13 @@
 package me.golf.blog.domain.board.domain.persist;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public final class SearchKeywordRequest {
-    private final String byTitle;
-
-    private final String byContent;
-
-    private final String byEmail;
+    private String title;
+    private String content;
+    private String email;
 }

--- a/src/main/java/me/golf/blog/domain/board/domain/vo/BoardImage.java
+++ b/src/main/java/me/golf/blog/domain/board/domain/vo/BoardImage.java
@@ -9,12 +9,13 @@ import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotBlank;
+import java.io.Serializable;
 import java.util.Objects;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
-public final class BoardImage {
+public final class BoardImage implements Serializable {
     @NotBlank(message = "필수 값입니다. - boardImage")
     @Column(name = "board_image")
     private String boardImage;

--- a/src/main/java/me/golf/blog/domain/board/domain/vo/Content.java
+++ b/src/main/java/me/golf/blog/domain/board/domain/vo/Content.java
@@ -9,12 +9,13 @@ import org.hibernate.validator.constraints.Length;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.validation.constraints.NotBlank;
+import java.io.Serializable;
 import java.util.Objects;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
-public final class Content {
+public final class Content implements Serializable {
 
     @NotBlank(message = "필수 값입니다.")
     @Length(min = 20, max = 500)

--- a/src/main/java/me/golf/blog/domain/board/domain/vo/Title.java
+++ b/src/main/java/me/golf/blog/domain/board/domain/vo/Title.java
@@ -10,12 +10,13 @@ import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotBlank;
+import java.io.Serializable;
 import java.util.Objects;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
-public final class Title {
+public final class Title implements Serializable {
 
     @Length(min = 6, max = 30)
     @NotBlank(message = "필수 값입니다.")

--- a/src/main/java/me/golf/blog/domain/board/dto/BoardDTO.java
+++ b/src/main/java/me/golf/blog/domain/board/dto/BoardDTO.java
@@ -23,7 +23,7 @@ public class BoardDTO {
     private Long boardCountId;
 
     public static BoardDTO of(final Board board) {
-        return new BoardDTO(board.getTitle(), board.getContent(), board.getBoardImage(), board.getLastModifiedTime(), board.getCreatedBy(),
-                board.getBoardCount().getId());
+        return new BoardDTO(board.getTitle(), board.getContent(), board.getBoardImage(),
+                board.getLastModifiedTime(), board.getCreatedBy(), board.getBoardCount().getId());
     }
 }

--- a/src/main/java/me/golf/blog/domain/board/dto/BoardDTO.java
+++ b/src/main/java/me/golf/blog/domain/board/dto/BoardDTO.java
@@ -1,5 +1,7 @@
 package me.golf.blog.domain.board.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,17 +11,29 @@ import me.golf.blog.domain.board.domain.vo.BoardImage;
 import me.golf.blog.domain.board.domain.vo.Content;
 import me.golf.blog.domain.board.domain.vo.Title;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class BoardDTO {
+public class BoardDTO implements Serializable {
+    public static final long serialVersionUID = 2L;
+
+    @JsonProperty("title")
     private Title title;
+
+    @JsonProperty("content")
     private Content content;
+
+    @JsonProperty("boardImage")
     private BoardImage boardImage;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-mm-dd")
     private LocalDateTime lastModifiedAt;
+
     private String createdBy;
+
     private Long boardCountId;
 
     public static BoardDTO of(final Board board) {

--- a/src/main/java/me/golf/blog/domain/boardCount/application/BoardCountService.java
+++ b/src/main/java/me/golf/blog/domain/boardCount/application/BoardCountService.java
@@ -1,7 +1,9 @@
 package me.golf.blog.domain.boardCount.application;
 
 import lombok.RequiredArgsConstructor;
+import me.golf.blog.domain.board.domain.persist.Board;
 import me.golf.blog.domain.board.dto.BoardDTO;
+import me.golf.blog.domain.boardCount.domain.persist.BoardCount;
 import me.golf.blog.domain.boardCount.domain.persist.BoardCountRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BoardCountService {
     private final BoardCountRepository boardCountRepository;
+
+    public void saveBoardCount(final Board board) {
+        BoardCount boardCount = BoardCount.createBoardCount(board);
+        boardCountRepository.save(boardCount);
+    }
 
     public int increaseViewCount(final BoardDTO board) {
         return boardCountRepository.updateView(board.getBoardCountId());

--- a/src/main/java/me/golf/blog/domain/boardCount/domain/persist/BoardCount.java
+++ b/src/main/java/me/golf/blog/domain/boardCount/domain/persist/BoardCount.java
@@ -4,6 +4,7 @@ import lombok.*;
 import me.golf.blog.domain.board.domain.persist.Board;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -17,8 +18,10 @@ public class BoardCount {
     @Column(name = "board_count_id", nullable = false, updatable = false)
     private Long id;
 
+    @Builder.Default
     private int viewCount = 0;
 
+    @Builder.Default
     private int likeCount = 0;
 
     @OneToOne(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
@@ -34,5 +37,18 @@ public class BoardCount {
     public void addBoard(final Board board) {
         this.board = board;
         board.addBoardCount(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BoardCount boardCount = (BoardCount) o;
+        return Objects.equals(id, boardCount.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/me/golf/blog/domain/member/api/MemberController.java
+++ b/src/main/java/me/golf/blog/domain/member/api/MemberController.java
@@ -2,6 +2,7 @@ package me.golf.blog.domain.member.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.golf.blog.domain.member.application.MemberReadService;
 import me.golf.blog.domain.member.dto.MemberUpdateRequest;
 import me.golf.blog.global.security.principal.CustomUserDetails;
 import me.golf.blog.domain.member.application.MemberService;
@@ -22,6 +23,7 @@ import javax.validation.Valid;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MemberReadService memberReadService;
 
     // create
     @PostMapping("/public/members")
@@ -32,7 +34,7 @@ public class MemberController {
     // read
     @GetMapping("/members/id")
     public ResponseEntity<MemberResponse> findMember() {
-        return ResponseEntity.ok().body(memberService.findOne(getPrincipal().getId()));
+        return ResponseEntity.ok().body(memberReadService.findById(getPrincipal().getId()));
     }
 
     // update

--- a/src/main/java/me/golf/blog/domain/member/application/MemberReadService.java
+++ b/src/main/java/me/golf/blog/domain/member/application/MemberReadService.java
@@ -3,7 +3,7 @@ package me.golf.blog.domain.member.application;
 import lombok.RequiredArgsConstructor;
 import me.golf.blog.domain.member.dto.MemberDTO;
 import me.golf.blog.domain.member.dto.MemberResponse;
-import me.golf.blog.domain.member.error.MemberNotFoundException;
+import me.golf.blog.domain.member.error.MemberCountNotFoundException;
 import me.golf.blog.domain.memberCount.domain.persist.MemberCount;
 import me.golf.blog.domain.memberCount.domain.persist.MemberCountRepository;
 import me.golf.blog.global.error.exception.ErrorCode;
@@ -19,8 +19,8 @@ public class MemberReadService {
 
     public MemberResponse findById(final Long memberId) {
         MemberDTO member = memberService.getMember(memberId);
-        MemberCount memberCount = memberCountRepository.findById(member.getMemberCountId()).orElseThrow(
-                () -> new MemberNotFoundException(ErrorCode.USER_NOT_FOUND));
+        MemberCount memberCount = memberCountRepository.findById(member.getMemberCountId())
+                .orElseThrow(() -> new MemberCountNotFoundException(ErrorCode.USER_COUNT_NOT_FOUND));
 
         return MemberResponse.of(member, memberCount);
     }

--- a/src/main/java/me/golf/blog/domain/member/application/MemberReadService.java
+++ b/src/main/java/me/golf/blog/domain/member/application/MemberReadService.java
@@ -1,0 +1,27 @@
+package me.golf.blog.domain.member.application;
+
+import lombok.RequiredArgsConstructor;
+import me.golf.blog.domain.member.dto.MemberDTO;
+import me.golf.blog.domain.member.dto.MemberResponse;
+import me.golf.blog.domain.member.error.MemberNotFoundException;
+import me.golf.blog.domain.memberCount.domain.persist.MemberCount;
+import me.golf.blog.domain.memberCount.domain.persist.MemberCountRepository;
+import me.golf.blog.global.error.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberReadService {
+    private final MemberService memberService;
+    private final MemberCountRepository memberCountRepository;
+
+    public MemberResponse findById(final Long memberId) {
+        MemberDTO member = memberService.getMember(memberId);
+        MemberCount memberCount = memberCountRepository.findById(member.getMemberCountId()).orElseThrow(
+                () -> new MemberNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        return MemberResponse.of(member, memberCount);
+    }
+}

--- a/src/main/java/me/golf/blog/domain/member/application/MemberService.java
+++ b/src/main/java/me/golf/blog/domain/member/application/MemberService.java
@@ -1,25 +1,30 @@
 package me.golf.blog.domain.member.application;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.golf.blog.domain.member.domain.persist.Member;
+import me.golf.blog.domain.member.domain.persist.MemberQueryRepository;
 import me.golf.blog.domain.member.domain.persist.MemberRepository;
 import me.golf.blog.domain.member.dto.JoinResponse;
 import me.golf.blog.domain.member.dto.MemberDTO;
-import me.golf.blog.domain.member.dto.MemberResponse;
 import me.golf.blog.domain.member.error.MemberNotFoundException;
 import me.golf.blog.domain.memberCount.application.MemberCountService;
-import me.golf.blog.domain.memberCount.domain.persist.MemberCountRepository;
 import me.golf.blog.global.error.exception.ErrorCode;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder encoder;
     private final MemberCountService memberCountService;
+    private final MemberQueryRepository memberQueryRepository;
 
     // create
     public JoinResponse create(final Member member) {
@@ -29,20 +34,27 @@ public class MemberService {
 
     // find
     @Cacheable(key = "#memberId", value = "getMember")
+    @Transactional(readOnly = true)
     public MemberDTO getMember(final Long memberId) {
-        return memberRepository.findById(memberId)
-                .map(MemberDTO::of)
-                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.USER_NOT_FOUND));
+        log.debug("getMember");
+        return memberQueryRepository.findByIdWithQuery(memberId).orElseThrow(
+                () -> new MemberNotFoundException(ErrorCode.USER_NOT_FOUND));
     }
 
     // update
     public void update(final Member updateMember, final Long id) {
         memberRepository.findById(id).orElseThrow(
-                () -> new MemberNotFoundException(ErrorCode.USER_NOT_FOUND)).update(updateMember);
+                () -> new MemberNotFoundException(ErrorCode.USER_NOT_FOUND)).update(updateMember, encoder);
     }
 
     // delete
-    public void delete(final Long id) {
-        memberRepository.deleteById(id);
+    public void delete(final Long memberId) {
+        deleteCache(memberId);
+        memberRepository.updateActivatedById(memberId);
+    }
+
+    @CacheEvict(value = "getMember", key = "#memberId")
+    public void deleteCache(final Long memberId) {
+        log.debug("회원 캐시 삭제 : {}", memberId);
     }
 }

--- a/src/main/java/me/golf/blog/domain/member/application/MemberService.java
+++ b/src/main/java/me/golf/blog/domain/member/application/MemberService.java
@@ -4,8 +4,11 @@ import lombok.RequiredArgsConstructor;
 import me.golf.blog.domain.member.domain.persist.Member;
 import me.golf.blog.domain.member.domain.persist.MemberRepository;
 import me.golf.blog.domain.member.dto.JoinResponse;
+import me.golf.blog.domain.member.dto.MemberDTO;
 import me.golf.blog.domain.member.dto.MemberResponse;
 import me.golf.blog.domain.member.error.MemberNotFoundException;
+import me.golf.blog.domain.memberCount.application.MemberCountService;
+import me.golf.blog.domain.memberCount.domain.persist.MemberCountRepository;
 import me.golf.blog.global.error.exception.ErrorCode;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,17 +19,19 @@ import org.springframework.stereotype.Service;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder encoder;
+    private final MemberCountService memberCountService;
 
     // create
     public JoinResponse create(final Member member) {
+        memberCountService.saveMemberCount(member);
         return JoinResponse.of(memberRepository.save(member.encode(encoder)));
     }
 
     // find
-    @Cacheable(key = "#memberId", value = "findOne")
-    public MemberResponse findOne(final Long memberId) {
+    @Cacheable(key = "#memberId", value = "getMember")
+    public MemberDTO getMember(final Long memberId) {
         return memberRepository.findById(memberId)
-                .map(MemberResponse::of)
+                .map(MemberDTO::of)
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.USER_NOT_FOUND));
     }
 

--- a/src/main/java/me/golf/blog/domain/member/domain/persist/Member.java
+++ b/src/main/java/me/golf/blog/domain/member/domain/persist/Member.java
@@ -2,7 +2,9 @@ package me.golf.blog.domain.member.domain.persist;
 
 import lombok.*;
 import me.golf.blog.domain.board.domain.persist.Board;
+import me.golf.blog.domain.boardCount.domain.persist.BoardCount;
 import me.golf.blog.domain.member.domain.vo.*;
+import me.golf.blog.domain.memberCount.domain.persist.MemberCount;
 import me.golf.blog.global.common.BaseTimeEntity;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -49,9 +51,16 @@ public class Member extends BaseTimeEntity {
     @OrderBy("title.title")
     private final List<Board> boards = new ArrayList<>();
 
+    @OneToOne(mappedBy = "member", fetch = FetchType.EAGER)
+    private MemberCount memberCount;
+
     // == 연관관계 로직 == //
     public void addBoard(final Board board) {
         boards.add(board);
+    }
+
+    public void addMemberCount(final MemberCount memberCount) {
+        this.memberCount = memberCount;
     }
 
     // == 비즈니스 로직 == //

--- a/src/main/java/me/golf/blog/domain/member/domain/persist/Member.java
+++ b/src/main/java/me/golf/blog/domain/member/domain/persist/Member.java
@@ -6,7 +6,10 @@ import me.golf.blog.domain.boardCount.domain.persist.BoardCount;
 import me.golf.blog.domain.member.domain.vo.*;
 import me.golf.blog.domain.memberCount.domain.persist.MemberCount;
 import me.golf.blog.global.common.BaseTimeEntity;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
@@ -15,13 +18,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 @DynamicUpdate
+@DynamicInsert
+@Where(clause = "activated = true")
 @Table(indexes = @Index(name = "i_email", columnList = "email"))
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,11 +52,14 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private RoleType role;
 
-    @OneToMany(mappedBy = "member", cascade = {CascadeType.MERGE, CascadeType.REMOVE})
+    @Column(name = "activated", columnDefinition = "boolean default true")
+    private Boolean activated = true;
+
+    @OneToMany(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @OrderBy("title.title")
     private final List<Board> boards = new ArrayList<>();
 
-    @OneToOne(mappedBy = "member", fetch = FetchType.EAGER)
+    @OneToOne(mappedBy = "member", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private MemberCount memberCount;
 
     // == 연관관계 로직 == //
@@ -69,11 +77,16 @@ public class Member extends BaseTimeEntity {
         return this;
     }
 
-    public Member update(final Member member) {
-        this.email = member.getEmail();
+    public Member update(final Member member, final PasswordEncoder encoder) {
+        this.password = Password.encode(member.getPassword().password(), encoder);
         this.nickname = member.getNickname();
         this.name = member.getName();
         return this;
+    }
+
+    public void delete() {
+        activated = false;
+        recordDeleteTime();
     }
 
     @Override

--- a/src/main/java/me/golf/blog/domain/member/domain/persist/MemberQueryRepository.java
+++ b/src/main/java/me/golf/blog/domain/member/domain/persist/MemberQueryRepository.java
@@ -1,0 +1,62 @@
+package me.golf.blog.domain.member.domain.persist;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import me.golf.blog.domain.member.domain.vo.Email;
+import me.golf.blog.domain.member.domain.vo.Password;
+import me.golf.blog.domain.member.dto.MemberDTO;
+import me.golf.blog.global.security.principal.CustomUserDetails;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static me.golf.blog.domain.member.domain.persist.QMember.*;
+import static me.golf.blog.domain.memberCount.domain.persist.QMemberCount.*;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepository {
+    private final JPAQueryFactory query;
+
+    public Optional<MemberDTO> findByIdWithQuery(final Long memberId) {
+        MemberDTO memberDTO = query.select(Projections.constructor(MemberDTO.class,
+                        memberCount.member.email,
+                        memberCount.member.name,
+                        memberCount.member.nickname,
+                        memberCount.member.birth,
+                        memberCount.id.as("memberCountId")))
+                .from(memberCount)
+                .join(memberCount.member, member)
+                .where(memberCount.member.id.eq(memberId))
+                .fetchOne();
+
+        return Optional.ofNullable(memberDTO);
+    }
+
+    public Optional<CustomUserDetails> findByEmail(final Email email) {
+        return Optional.ofNullable(
+                query.select(Projections.constructor(CustomUserDetails.class,
+                                member.id.as("id"),
+                                member.email,
+                                member.password,
+                                member.role))
+                        .from(member)
+                        .where(member.email.eq(email))
+                        .fetchOne()
+        );
+    }
+
+    public Optional<CustomUserDetails> findById(Long memberId) {
+        return Optional.ofNullable(
+                query.select(Projections.constructor(CustomUserDetails.class,
+                                member.id.as("id"),
+                                member.email,
+                                member.password,
+                                member.role))
+                        .from(member)
+                        .where(member.id.eq(memberId))
+                        .fetchOne()
+        );
+    }
+}

--- a/src/main/java/me/golf/blog/domain/member/domain/persist/MemberRepository.java
+++ b/src/main/java/me/golf/blog/domain/member/domain/persist/MemberRepository.java
@@ -1,10 +1,18 @@
 package me.golf.blog.domain.member.domain.persist;
 
-import me.golf.blog.domain.member.domain.vo.Email;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(final Email email);
+    @EntityGraph(attributePaths = "memberCount")
+    Optional<Member> findById(final Long id);
+
+    @Modifying
+    @Query("update Member m set m.activated = false where m.id = :id")
+    void updateActivatedById(@Param("id") Long id);
 }

--- a/src/main/java/me/golf/blog/domain/member/domain/vo/Email.java
+++ b/src/main/java/me/golf/blog/domain/member/domain/vo/Email.java
@@ -8,12 +8,13 @@ import lombok.NoArgsConstructor;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.validation.constraints.NotBlank;
+import java.io.Serializable;
 import java.util.Objects;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public final class Email {
+public final class Email implements Serializable {
     @javax.validation.constraints.Email
     @NotBlank(message = "필수 값입니다.")
     @Column(unique = true, nullable = false)

--- a/src/main/java/me/golf/blog/domain/member/domain/vo/Name.java
+++ b/src/main/java/me/golf/blog/domain/member/domain/vo/Name.java
@@ -8,12 +8,13 @@ import lombok.NoArgsConstructor;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.validation.constraints.NotBlank;
+import java.io.Serializable;
 import java.util.Objects;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public final class Name {
+public final class Name implements Serializable {
     @Column(nullable = false, length = 13)
     @NotBlank(message = "필수 값입니다.")
     private String name;

--- a/src/main/java/me/golf/blog/domain/member/domain/vo/Nickname.java
+++ b/src/main/java/me/golf/blog/domain/member/domain/vo/Nickname.java
@@ -8,12 +8,13 @@ import lombok.NoArgsConstructor;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.validation.constraints.NotBlank;
+import java.io.Serializable;
 import java.util.Objects;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public final class Nickname {
+public final class Nickname implements Serializable {
     @Column(name = "nickname", nullable = false, unique = true)
     @NotBlank(message = "필수 값입니다.")
     private String nickname;

--- a/src/main/java/me/golf/blog/domain/member/dto/JoinResponse.java
+++ b/src/main/java/me/golf/blog/domain/member/dto/JoinResponse.java
@@ -14,14 +14,11 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class JoinResponse {
-
-    @NotBlank(message = "필수 값입니다.")
+    private Long memberId;
     private Email email;
-
-    @NotBlank(message = "필수 값입니다.")
     private Name name;
 
     public static JoinResponse of(final Member member) {
-        return new JoinResponse(member.getEmail(), member.getName());
+        return new JoinResponse(member.getId(), member.getEmail(), member.getName());
     }
 }

--- a/src/main/java/me/golf/blog/domain/member/dto/MemberDTO.java
+++ b/src/main/java/me/golf/blog/domain/member/dto/MemberDTO.java
@@ -1,32 +1,37 @@
 package me.golf.blog.domain.member.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
 import me.golf.blog.domain.member.domain.persist.Member;
 import me.golf.blog.domain.member.domain.vo.Email;
 import me.golf.blog.domain.member.domain.vo.Name;
 import me.golf.blog.domain.member.domain.vo.Nickname;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.SpringSecurityCoreVersion;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class MemberDTO {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class MemberDTO implements Serializable {
+    private final long serialVersionUID = 1L;
+
+    @JsonProperty("email")
     private Email email;
+
+    @JsonProperty("name")
     private Name name;
+
+    @JsonProperty("nickname")
     private Nickname nickname;
-    private int age;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-mm-dd")
+    @DateTimeFormat(pattern = "yyyy-mm-dd")
+    private LocalDate birth;
+
     private Long memberCountId;
-
-    public static MemberDTO of(final Member member) {
-        LocalDate birth = member.getBirth();
-        int memberYear = birth.getYear();
-        int nowYear = LocalDate.now().getYear();
-
-        return new MemberDTO(member.getEmail(), member.getName(), member.getNickname(), nowYear - memberYear,
-                member.getMemberCount().getId());
-    }
 }

--- a/src/main/java/me/golf/blog/domain/member/dto/MemberDTO.java
+++ b/src/main/java/me/golf/blog/domain/member/dto/MemberDTO.java
@@ -8,24 +8,25 @@ import me.golf.blog.domain.member.domain.persist.Member;
 import me.golf.blog.domain.member.domain.vo.Email;
 import me.golf.blog.domain.member.domain.vo.Name;
 import me.golf.blog.domain.member.domain.vo.Nickname;
-import me.golf.blog.domain.memberCount.domain.persist.MemberCount;
 
 import java.time.LocalDate;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class MemberResponse {
+public class MemberDTO {
     private Email email;
     private Name name;
     private Nickname nickname;
     private int age;
-    private int followerCount;
-    private int followingCount;
-    private int boardCount;
+    private Long memberCountId;
 
-    public static MemberResponse of(final MemberDTO member, final MemberCount memberCount) {
-        return new MemberResponse(member.getEmail(), member.getName(), member.getNickname(), member.getAge(),
-                memberCount.getFollowerCount(), memberCount.getFollowingCount(), memberCount.getBoardCount());
+    public static MemberDTO of(final Member member) {
+        LocalDate birth = member.getBirth();
+        int memberYear = birth.getYear();
+        int nowYear = LocalDate.now().getYear();
+
+        return new MemberDTO(member.getEmail(), member.getName(), member.getNickname(), nowYear - memberYear,
+                member.getMemberCount().getId());
     }
 }

--- a/src/main/java/me/golf/blog/domain/member/dto/MemberResponse.java
+++ b/src/main/java/me/golf/blog/domain/member/dto/MemberResponse.java
@@ -25,7 +25,10 @@ public class MemberResponse {
     private int boardCount;
 
     public static MemberResponse of(final MemberDTO member, final MemberCount memberCount) {
-        return new MemberResponse(member.getEmail(), member.getName(), member.getNickname(), member.getAge(),
+        int memberYear = member.getBirth().getYear();
+        int now = LocalDate.now().getYear();
+
+        return new MemberResponse(member.getEmail(), member.getName(), member.getNickname(), now - memberYear,
                 memberCount.getFollowerCount(), memberCount.getFollowingCount(), memberCount.getBoardCount());
     }
 }

--- a/src/main/java/me/golf/blog/domain/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/me/golf/blog/domain/member/dto/MemberUpdateRequest.java
@@ -9,6 +9,7 @@ import me.golf.blog.domain.member.domain.persist.Member;
 import me.golf.blog.domain.member.domain.vo.Email;
 import me.golf.blog.domain.member.domain.vo.Name;
 import me.golf.blog.domain.member.domain.vo.Nickname;
+import me.golf.blog.domain.member.domain.vo.Password;
 
 import javax.validation.constraints.NotBlank;
 
@@ -16,8 +17,8 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberUpdateRequest {
-    @JsonProperty("email")
-    private Email email;
+    @JsonProperty("password")
+    private Password password;
 
     @JsonProperty("nickname")
     private Nickname nickname;
@@ -25,13 +26,13 @@ public class MemberUpdateRequest {
     @JsonProperty("name")
     private Name name;
 
-    public static MemberUpdateRequest of(final Email email, final Nickname nickname, final Name name) {
-        return new MemberUpdateRequest(email, nickname, name);
+    public static MemberUpdateRequest of(final Password password, final Nickname nickname, final Name name) {
+        return new MemberUpdateRequest(password, nickname, name);
     }
 
     public Member toEntity() {
         return Member.builder()
-                .email(email)
+                .password(password)
                 .nickname(nickname)
                 .name(name)
                 .build();

--- a/src/main/java/me/golf/blog/domain/member/error/MemberCountNotFoundException.java
+++ b/src/main/java/me/golf/blog/domain/member/error/MemberCountNotFoundException.java
@@ -1,0 +1,10 @@
+package me.golf.blog.domain.member.error;
+
+import me.golf.blog.global.error.exception.EntityNotFoundException;
+import me.golf.blog.global.error.exception.ErrorCode;
+
+public class MemberCountNotFoundException extends EntityNotFoundException {
+    public MemberCountNotFoundException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/me/golf/blog/domain/memberCount/application/MemberCountService.java
+++ b/src/main/java/me/golf/blog/domain/memberCount/application/MemberCountService.java
@@ -1,0 +1,24 @@
+package me.golf.blog.domain.memberCount.application;
+
+import lombok.RequiredArgsConstructor;
+import me.golf.blog.domain.member.domain.persist.Member;
+import me.golf.blog.domain.memberCount.domain.persist.MemberCount;
+import me.golf.blog.domain.memberCount.domain.persist.MemberCountRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberCountService {
+    private final MemberCountRepository memberCountRepository;
+
+    public void saveMemberCount(final Member member) {
+        MemberCount memberCount = MemberCount.createMemberCount(member);
+        memberCountRepository.save(memberCount);
+    }
+
+    public void increaseBoardCount(final Member member) {
+        memberCountRepository.updateBoardCount(member.getMemberCount().getId());
+    }
+}

--- a/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCount.java
+++ b/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCount.java
@@ -1,0 +1,58 @@
+package me.golf.blog.domain.memberCount.domain.persist;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import me.golf.blog.domain.member.domain.persist.Member;
+import me.golf.blog.global.common.BaseTimeEntity;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "member_count")
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberCount extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_count_id", nullable = false)
+    private Long id;
+
+    @Builder.Default
+    private int followerCount = 0;
+
+    @Builder.Default
+    private int followingCount = 0;
+
+    @Builder.Default
+    private int boardCount = 0;
+
+    @OneToOne(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    private Member member;
+
+    public static MemberCount createMemberCount(final Member member) {
+        MemberCount memberCount = new MemberCount();
+        memberCount.addMember(member);
+        return memberCount;
+    }
+
+    public void addMember(final Member member) {
+        this.member = member;
+        member.addMemberCount(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MemberCount memberCount = (MemberCount) o;
+        return Objects.equals(this.id, memberCount.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCount.java
+++ b/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCount.java
@@ -27,7 +27,8 @@ public class MemberCount extends BaseTimeEntity {
     @Builder.Default
     private int boardCount = 0;
 
-    @OneToOne(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @JoinColumn(name = "member_id", unique = true, nullable = false)
     private Member member;
 
     public static MemberCount createMemberCount(final Member member) {

--- a/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCount.java
+++ b/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCount.java
@@ -1,15 +1,13 @@
 package me.golf.blog.domain.memberCount.domain.persist;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import me.golf.blog.domain.member.domain.persist.Member;
 import me.golf.blog.global.common.BaseTimeEntity;
 
 import javax.persistence.*;
 import java.util.Objects;
 
+@Getter
 @Entity
 @Table(name = "member_count")
 @Builder

--- a/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCountRepository.java
+++ b/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCountRepository.java
@@ -1,6 +1,20 @@
 package me.golf.blog.domain.memberCount.domain.persist;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberCountRepository extends JpaRepository<MemberCount, Long> {
+    @Modifying
+    @Query("update MemberCount m set m.followingCount = m.followingCount + 1 where m.id = :id")
+    int updateFollowingCount(@Param("id")Long id);
+
+    @Modifying
+    @Query("update MemberCount m set m.followerCount = m.followerCount + 1 where m.id = :id")
+    int updateFollowerCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("update MemberCount m set m.boardCount = m.boardCount + 1 where m.id = :id")
+    int updateBoardCount(@Param("id") Long id);
 }

--- a/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCountRepository.java
+++ b/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCountRepository.java
@@ -1,9 +1,12 @@
 package me.golf.blog.domain.memberCount.domain.persist;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MemberCountRepository extends JpaRepository<MemberCount, Long> {
     @Modifying
@@ -16,5 +19,8 @@ public interface MemberCountRepository extends JpaRepository<MemberCount, Long> 
 
     @Modifying
     @Query("update MemberCount m set m.boardCount = m.boardCount + 1 where m.id = :id")
-    int updateBoardCount(@Param("id") Long id);
+    void updateBoardCount(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = "member")
+    Optional<MemberCount> findById(Long id);
 }

--- a/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCountRepository.java
+++ b/src/main/java/me/golf/blog/domain/memberCount/domain/persist/MemberCountRepository.java
@@ -1,0 +1,6 @@
+package me.golf.blog.domain.memberCount.domain.persist;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberCountRepository extends JpaRepository<MemberCount, Long> {
+}

--- a/src/main/java/me/golf/blog/domain/reply/persist/Reply.java
+++ b/src/main/java/me/golf/blog/domain/reply/persist/Reply.java
@@ -31,7 +31,8 @@ public class Reply extends BaseTimeEntity {
     @JoinColumn(name = "board_id")
     private Board board;
 
-    public void updateComment(final Comment comment) {
+    public Reply updateComment(final Comment comment) {
         this.comment = comment;
+        return this;
     }
 }

--- a/src/main/java/me/golf/blog/global/common/BaseTimeEntity.java
+++ b/src/main/java/me/golf/blog/global/common/BaseTimeEntity.java
@@ -22,4 +22,11 @@ public class BaseTimeEntity {
     @LastModifiedDate
     @Column(name = "last_modified_time")
     private LocalDateTime lastModifiedTime;
+
+    @Column(name = "delete_time")
+    private LocalDateTime deleteTime;
+
+    public void recordDeleteTime() {
+        this.deleteTime = LocalDateTime.now();
+    }
 }

--- a/src/main/java/me/golf/blog/global/config/CacheConfig.java
+++ b/src/main/java/me/golf/blog/global/config/CacheConfig.java
@@ -1,9 +1,5 @@
 package me.golf.blog.global.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
@@ -11,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -23,21 +19,11 @@ public class CacheConfig {
     private final RedisConnectionFactory redisConnectionFactory;
 
     @Bean
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper()
-                .findAndRegisterModules()
-                .enable(SerializationFeature.INDENT_OUTPUT)
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .registerModule(new JavaTimeModule());
-    }
-
-    @Bean
     public CacheManager cacheManager() {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.
-                        SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper())))
+                        SerializationPair.fromSerializer(new JdkSerializationRedisSerializer()))
                 .entryTtl(Duration.ofSeconds(30));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)

--- a/src/main/java/me/golf/blog/global/config/RedisConfig.java
+++ b/src/main/java/me/golf/blog/global/config/RedisConfig.java
@@ -33,7 +33,7 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<?, ?> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());

--- a/src/main/java/me/golf/blog/global/error/exception/ErrorCode.java
+++ b/src/main/java/me/golf/blog/global/error/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     // Member
     PASSWORD_NULL_ERROR(400, "M001", "비밀번호가 없습니다."),
     USER_NOT_FOUND(400, "M002", "없는 회원 입니다."),
+    USER_COUNT_NOT_FOUND(400, "M003", "해당 MemberCount가 존재하지 않습니다."),
 
     // JWT
     TOKEN_NOT_FOUND(400, "J001", "잘못된 토큰입니다."),

--- a/src/main/java/me/golf/blog/global/security/principal/CustomUserDetails.java
+++ b/src/main/java/me/golf/blog/global/security/principal/CustomUserDetails.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class CustomUserDetails implements UserDetails, Serializable {
 
     private final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;

--- a/src/main/java/me/golf/blog/global/security/principal/CustomUserDetailsService.java
+++ b/src/main/java/me/golf/blog/global/security/principal/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package me.golf.blog.global.security.principal;
 
 import lombok.RequiredArgsConstructor;
+import me.golf.blog.domain.member.domain.persist.MemberQueryRepository;
 import me.golf.blog.domain.member.domain.persist.MemberRepository;
 import me.golf.blog.domain.member.error.MemberNotFoundException;
 import me.golf.blog.global.error.exception.ErrorCode;
@@ -12,14 +13,13 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
-    private final MemberRepository memberRepository;
+    private final MemberQueryRepository memberQueryRepository;
     public static final MemberNotFoundException NOT_FOUND_EXCEPTION =
             new MemberNotFoundException(ErrorCode.USER_NOT_FOUND);
 
     @Override
     public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
-        return memberRepository.findById(Long.valueOf(id))
-                .map(CustomUserDetails::of)
+        return memberQueryRepository.findById(Long.valueOf(id))
                 .orElseThrow(() -> NOT_FOUND_EXCEPTION);
     }
 }

--- a/src/test/java/me/golf/blog/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/me/golf/blog/domain/auth/api/AuthControllerTest.java
@@ -58,9 +58,11 @@ class AuthControllerTest {
     @Autowired
     TokenProvider tokenProvider;
 
+    static Long memberId;
+
     @BeforeEach
     public void init() {
-        memberRepository.save(toEntity());
+        memberId = memberRepository.save(toEntity()).getId();
     }
 
     @Test
@@ -75,7 +77,7 @@ class AuthControllerTest {
 
         UsernamePasswordAuthenticationToken token =
                 new UsernamePasswordAuthenticationToken(GIVEN_EMAIL, GIVEN_PASSWORD, authorities);
-        TokenDTO tokenDTO = tokenProvider.createToken(GIVEN_EMAIL.email(), token);
+        TokenDTO tokenDTO = tokenProvider.createToken(memberId, token);
 
         // when
         when(authService.login(any(), any())).thenReturn(tokenDTO);
@@ -103,7 +105,7 @@ class AuthControllerTest {
 
         UsernamePasswordAuthenticationToken token =
                 new UsernamePasswordAuthenticationToken(GIVEN_EMAIL, GIVEN_PASSWORD, authorities);
-        TokenDTO tokenDTO = tokenProvider.createToken(GIVEN_EMAIL.email(), token);
+        TokenDTO tokenDTO = tokenProvider.createToken(memberId, token);
 
         // when
         when(authService.reissue(any())).thenReturn(tokenDTO.getAccessToken());
@@ -128,7 +130,7 @@ class AuthControllerTest {
 
         UsernamePasswordAuthenticationToken token =
                 new UsernamePasswordAuthenticationToken(GIVEN_EMAIL, GIVEN_PASSWORD, authorities);
-        TokenDTO tokenDTO = tokenProvider.createToken(GIVEN_EMAIL.email(), token);
+        TokenDTO tokenDTO = tokenProvider.createToken(memberId, token);
 
         // when
         mockMvc.perform(delete("/api/v1/auth/logout")

--- a/src/test/java/me/golf/blog/domain/board/api/BoardControllerTest.java
+++ b/src/test/java/me/golf/blog/domain/board/api/BoardControllerTest.java
@@ -79,7 +79,7 @@ class BoardControllerTest {
 
         when(boardReadService.findById(any())).thenReturn(boardResponse);
 
-        mockMvc.perform(get("/api/v1/boards/1").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/api/v1/public/boards/1").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(document("board/findById",
                         responseFields(

--- a/src/test/java/me/golf/blog/domain/board/application/BoardServiceTest.java
+++ b/src/test/java/me/golf/blog/domain/board/application/BoardServiceTest.java
@@ -10,9 +10,14 @@ import me.golf.blog.domain.board.dto.BoardResponse;
 import me.golf.blog.domain.board.dto.BoardUpdateRequest;
 import me.golf.blog.domain.board.error.BoardNotFoundException;
 import me.golf.blog.domain.member.WithAuthUser;
+import me.golf.blog.domain.member.application.MemberService;
 import me.golf.blog.domain.member.domain.persist.Member;
 import me.golf.blog.domain.member.domain.persist.MemberRepository;
+import me.golf.blog.domain.member.dto.JoinResponse;
+import me.golf.blog.domain.member.error.MemberNotFoundException;
 import me.golf.blog.domain.member.util.GivenMember;
+import me.golf.blog.domain.memberCount.domain.persist.MemberCount;
+import me.golf.blog.domain.memberCount.domain.persist.MemberCountRepository;
 import me.golf.blog.global.error.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,24 +38,26 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 class BoardServiceTest {
 
-    @Autowired
-    BoardService boardService;
+    @Autowired BoardService boardService;
 
-    @Autowired
-    BoardRepository boardRepository;
+    @Autowired BoardRepository boardRepository;
 
-    @Autowired
-    MemberRepository memberRepository;
+    @Autowired MemberRepository memberRepository;
 
-    @Autowired
-    BoardReadService boardReadService;
+    @Autowired MemberService memberService;
+
+    @Autowired BoardReadService boardReadService;
 
     static Member member;
     static Long boardId;
 
     @BeforeEach
     void init() {
-        member = memberRepository.save(GivenMember.toEntity());
+        JoinResponse joinResponse = memberService.create(GivenMember.toEntity());
+        
+        member = memberRepository.findById(joinResponse.getMemberId()).orElseThrow(
+                () -> new MemberNotFoundException(ErrorCode.USER_NOT_FOUND));
+
         boardId = boardService.create(toEntity(), member.getId());
     }
 
@@ -110,7 +117,6 @@ class BoardServiceTest {
         // then
         assertThat(board.getTitle()).isEqualTo(Title.from("수정된 게시판 제목입니다."));
         assertThat(board.getContent()).isEqualTo(Content.from("안녕하세요 수정된 게시판 내용입니다."));
-//        assertThat(board.getLastModifiedBy()).isEqualTo();
         assertThat(board.getLastModifiedTime()).isBefore(LocalDateTime.now());
     }
 

--- a/src/test/java/me/golf/blog/domain/board/application/BoardServiceTest.java
+++ b/src/test/java/me/golf/blog/domain/board/application/BoardServiceTest.java
@@ -87,9 +87,9 @@ class BoardServiceTest {
         }
 
         SearchKeywordRequest keyword = SearchKeywordRequest.builder()
-                .byTitle(null)
-                .byContent(null)
-                .byEmail(null)
+                .title(null)
+                .content(null)
+                .email(null)
                 .build();
 
         Pageable pageable = PageRequest.of(0, 10);

--- a/src/test/java/me/golf/blog/domain/board/domain/persist/BoardQueryRepositoryTest.java
+++ b/src/test/java/me/golf/blog/domain/board/domain/persist/BoardQueryRepositoryTest.java
@@ -44,9 +44,9 @@ class BoardQueryRepositoryTest {
     void findAllKeyword() {
         // given
         SearchKeywordRequest keyword = SearchKeywordRequest.builder()
-                .byTitle("게시판 제목 3")
-                .byContent("게시판 내용입니다.")
-                .byEmail(GivenMember.GIVEN_NICKNAME.nickname())
+                .title("게시판 제목 3")
+                .content("게시판 내용입니다.")
+                .email(GivenMember.GIVEN_NICKNAME.nickname())
                 .build();
 
         List<BoardAllResponse> boards =
@@ -59,9 +59,9 @@ class BoardQueryRepositoryTest {
     @DisplayName("일부의 키워드만 보내면 동적으로 null에 대해 동작하지 않는다.")
     void findPartKeyword() {
         SearchKeywordRequest keyword = SearchKeywordRequest.builder()
-                .byTitle("게시판 제목 1")
-                .byContent("게시판 내용입니다. 안녕하세요 1")
-                .byEmail(null)
+                .title("게시판 제목 1")
+                .content("게시판 내용입니다. 안녕하세요 1")
+                .email(null)
                 .build();
 
         List<BoardAllResponse> boards =
@@ -74,9 +74,9 @@ class BoardQueryRepositoryTest {
     @DisplayName("아예 키워드가 없으면 where절은 제외 된다.")
     void findWithout() {
         SearchKeywordRequest keyword = SearchKeywordRequest.builder()
-                .byTitle(null)
-                .byContent(null)
-                .byEmail(null)
+                .title(null)
+                .content(null)
+                .email(null)
                 .build();
 
         List<BoardAllResponse> boards =

--- a/src/test/java/me/golf/blog/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/me/golf/blog/domain/member/api/MemberControllerTest.java
@@ -7,6 +7,7 @@ import me.golf.blog.domain.member.application.MemberService;
 import me.golf.blog.domain.member.domain.vo.Email;
 import me.golf.blog.domain.member.domain.vo.Name;
 import me.golf.blog.domain.member.domain.vo.Nickname;
+import me.golf.blog.domain.member.domain.vo.Password;
 import me.golf.blog.domain.member.dto.*;
 import me.golf.blog.domain.memberCount.domain.persist.MemberCount;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +19,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
 
 import static me.golf.blog.domain.member.util.GivenMember.*;
 import static org.mockito.Mockito.*;
@@ -76,7 +79,13 @@ class MemberControllerTest {
     @DisplayName("요청을 받아 정상적으로 조회 컨트롤러가 동작한다.")
     @WithAuthUser
     void findMemberTest() throws Exception {
-        MemberDTO memberDTO = MemberDTO.of(toEntityWithCount());
+        MemberDTO memberDTO = MemberDTO.builder()
+                .email(GIVEN_EMAIL)
+                .name(GIVEN_NAME)
+                .nickname(GIVEN_NICKNAME)
+                .birth(LocalDate.of(1996, 10, 25))
+                .memberCountId(1L)
+                .build();
         when(memberReadService.findById(any())).thenReturn(MemberResponse.of(memberDTO, MemberCount.builder().build()));
 
         mockMvc.perform(get("/api/v1/members/id").accept(MediaType.APPLICATION_JSON))
@@ -99,7 +108,7 @@ class MemberControllerTest {
     @WithAuthUser
     void updateTest() throws Exception {
         MemberUpdateRequest request = MemberUpdateRequest.of
-                (Email.from("ilgoll@naver.com"), Nickname.from("티오더"), Name.from("김티오"));
+                (Password.from("123456"), Nickname.from("티오더"), Name.from("김티오"));
         String body = objectMapper.writeValueAsString(request);
 
         mockMvc.perform(patch("/api/v1/members").content(body)
@@ -107,7 +116,7 @@ class MemberControllerTest {
                 .andExpect(status().isOk())
                 .andDo(document("/member/update",
                         requestFields(
-                                fieldWithPath("email").description("이메일"),
+                                fieldWithPath("password").description("비밀번호"),
                                 fieldWithPath("nickname").description("닉네임"),
                                 fieldWithPath("name").description("이름")
                         )))

--- a/src/test/java/me/golf/blog/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/me/golf/blog/domain/member/application/MemberServiceTest.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @Transactional
 class MemberServiceTest {
 
-    @Autowired
-    MemberService memberService;
+    @Autowired MemberService memberService;
+    @Autowired MemberReadService memberReadService;
 
     @BeforeEach
     void setUp() {
@@ -39,7 +39,7 @@ class MemberServiceTest {
     @DisplayName("회원정보를 조회해온다.")
     void findOne() {
         // when
-        MemberResponse member = memberService.findOne(2L);
+        MemberResponse member = memberReadService.findById(2L);
 
         // then
         assertThat(member.getEmail()).isEqualTo(GIVEN_EMAIL);
@@ -54,7 +54,7 @@ class MemberServiceTest {
 
         // when
         memberService.update(updateRequest.toEntity(), 3L);
-        MemberResponse member = memberService.findOne(3L);
+        MemberResponse member = memberReadService.findById(3L);
 
         // then
         assertThat(member.getEmail()).isEqualTo(Email.from("ilgolf@naver.com"));
@@ -69,6 +69,6 @@ class MemberServiceTest {
         memberService.delete(1L);
 
         // then
-        assertThrows(MemberNotFoundException.class, () -> memberService.findOne(1L));
+        assertThrows(MemberNotFoundException.class, () -> memberReadService.findById(1L));
     }
 }

--- a/src/test/java/me/golf/blog/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/me/golf/blog/domain/member/application/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package me.golf.blog.domain.member.application;
 
+import me.golf.blog.domain.member.domain.vo.Password;
 import me.golf.blog.domain.member.dto.MemberUpdateRequest;
 import me.golf.blog.domain.member.domain.vo.Email;
 import me.golf.blog.domain.member.domain.vo.Name;
@@ -29,17 +30,18 @@ class MemberServiceTest {
     @Autowired MemberService memberService;
     @Autowired MemberReadService memberReadService;
 
+    static Long memberId;
+
     @BeforeEach
     void setUp() {
-        JoinResponse joinResponse = memberService.create(toEntity());
-        System.out.println("joinResponse.getEmail() = " + joinResponse.getEmail().email());
+        memberId = memberService.create(toEntity()).getMemberId();
     }
 
     @Test
     @DisplayName("회원정보를 조회해온다.")
     void findOne() {
         // when
-        MemberResponse member = memberReadService.findById(2L);
+        MemberResponse member = memberReadService.findById(memberId);
 
         // then
         assertThat(member.getEmail()).isEqualTo(GIVEN_EMAIL);
@@ -50,14 +52,13 @@ class MemberServiceTest {
     @DisplayName("회원 정보를 업데이트 한다.")
     void update() {
         // given
-        MemberUpdateRequest updateRequest = MemberUpdateRequest.of(Email.from("ilgolf@naver.com"), Nickname.from("torder"), Name.from("김티오"));
+        MemberUpdateRequest updateRequest = MemberUpdateRequest.of(Password.from("123456"), Nickname.from("torder"), Name.from("김티오"));
 
         // when
-        memberService.update(updateRequest.toEntity(), 3L);
-        MemberResponse member = memberReadService.findById(3L);
+        memberService.update(updateRequest.toEntity(), memberId);
+        MemberResponse member = memberReadService.findById(memberId);
 
         // then
-        assertThat(member.getEmail()).isEqualTo(Email.from("ilgolf@naver.com"));
         assertThat(member.getNickname()).isNotEqualTo(GIVEN_NICKNAME);
         assertThat(member.getName()).isEqualTo(Name.from("김티오"));
     }
@@ -66,9 +67,9 @@ class MemberServiceTest {
     @DisplayName("회원 정보를 삭제한다.")
     void delete() {
         // when
-        memberService.delete(1L);
+        memberService.delete(memberId);
 
         // then
-        assertThrows(MemberNotFoundException.class, () -> memberReadService.findById(1L));
+        assertThrows(MemberNotFoundException.class, () -> memberService.getMember(memberId));
     }
 }

--- a/src/test/java/me/golf/blog/domain/member/domain/persist/MemberTest.java
+++ b/src/test/java/me/golf/blog/domain/member/domain/persist/MemberTest.java
@@ -20,17 +20,19 @@ class MemberTest {
     void update() {
         // given
         Member updateMember = Member.builder()
-                .email(Email.from("member@naver.com"))
+                .password(Password.from("123456"))
                 .nickname(Nickname.from("티오더"))
                 .name(Name.from("김티오"))
                 .build();
 
+        PasswordEncoder encoder = TestPasswordEncoder.initialize();
+
         // when
-        Member member = toEntity().update(updateMember);
+        Member member = toEntity().update(updateMember, encoder);
 
         // then
         assertAll(() -> {
-            assertEquals(member.getEmail(), updateMember.getEmail());
+            assertTrue(encoder.matches(updateMember.getPassword().password(), member.getPassword().password()));
             assertEquals(member.getName(), updateMember.getName());
             assertEquals(member.getNickname(), updateMember.getNickname());
         });

--- a/src/test/java/me/golf/blog/domain/member/util/GivenMember.java
+++ b/src/test/java/me/golf/blog/domain/member/util/GivenMember.java
@@ -6,6 +6,7 @@ import me.golf.blog.domain.member.domain.vo.Email;
 import me.golf.blog.domain.member.domain.vo.Name;
 import me.golf.blog.domain.member.domain.vo.Nickname;
 import me.golf.blog.domain.member.domain.vo.Password;
+import me.golf.blog.domain.memberCount.domain.persist.MemberCount;
 
 import java.time.LocalDate;
 
@@ -23,6 +24,18 @@ public class GivenMember {
                 .nickname(GIVEN_NICKNAME)
                 .name(GIVEN_NAME)
                 .role(RoleType.USER)
+                .birth(GIVEN_BIRTH)
+                .build();
+    }
+
+    public static Member toEntityWithCount() {
+        return Member.builder()
+                .email(GIVEN_EMAIL)
+                .password(GIVEN_PASSWORD)
+                .nickname(GIVEN_NICKNAME)
+                .name(GIVEN_NAME)
+                .role(RoleType.USER)
+                .memberCount(MemberCount.builder().build())
                 .birth(GIVEN_BIRTH)
                 .build();
     }


### PR DESCRIPTION
1.  memberCount Entity 작성

2. member 상세 조회 시 팔로잉 팔로워 게시판 개수 응답 필드에 추가

3. member 캐싱 시 데이터 불일치를 해결하기 위해 ReadService 구현 하여 캐싱한 데이터에서 memberCount 업데이트 후 전송

4. 테스트 로직 수정

5. boardCount MemberCount와 board member 각각 책임 분리 